### PR TITLE
Fix deviations from EurKEY 1.3 specifications and add better support for ISO keyboards

### DIFF
--- a/EurKEY.bundle/Contents/Resources/EurKEY.keylayout
+++ b/EurKEY.bundle/Contents/Resources/EurKEY.keylayout
@@ -108,7 +108,6 @@
 					<when state="none" output="x" />
 					<when state="α" output="ξ" />
 					<when state="¨" output="ẍ" />
-					<when state="√" output="∡" />
 				</action>
 			</key>
 			<key code="8">
@@ -259,6 +258,7 @@
 				<action>
 					<when state="none" output="7" />
 					<when state="α" output="⁷" />
+					<when state="√" output="∡" />
 				</action>
 			</key>
 			<key code="27">
@@ -796,7 +796,13 @@
 					<when state="ˇ" output="J̌" />
 				</action>
 			</key>
-			<key code="39" output="&#x0022;" />
+			<key code="39">
+				<action>
+					<when state="none" output="&#x0022;" />
+					<when state="α" output="₊" />
+					<when state="√" output="″" />
+				</action>
+			</key>
 			<key code="40">
 				<action>
 					<when state="none" output="K" />
@@ -886,24 +892,14 @@
 			</key>
 			<key code="23" output="€" />
 			<key code="24" output="×" />
-			<key code="25">
-				<action>
-					<when state="none" output="“" />
-					<when state="√" output="″" />
-				</action>
-			</key>
+			<key code="25" output="“" />
 			<key code="26">
 				<action>
 					<when state="none" next=" ̊" />
 				</action>
 			</key>
 			<key code="27" output="✓" />
-			<key code="28">
-				<action>
-					<when state="none" output="„" />
-					<when state="α" output="₊" />
-				</action>
-			</key>
+			<key code="28" output="„" />
 			<key code="29" output="”" />
 			<key code="30" output="»" />
 			<key code="31" output="ö" />

--- a/EurKEY.bundle/Contents/Resources/EurKEY.keylayout
+++ b/EurKEY.bundle/Contents/Resources/EurKEY.keylayout
@@ -469,7 +469,7 @@
 			<key code="109" output="&#x0010;" />
 			<key code="111" output="&#x0010;" />
 			<key code="113" output="&#x0010;" />
-			<key code="114" output="&#x0005;"/>
+			<key code="114" output="&#x0005;" />
 			<key code="115" output="&#x0001;" />
 			<key code="116" output="&#x000B;" />
 			<key code="117" output="&#x007F;" />
@@ -1082,7 +1082,6 @@
 					<when state="none" output="X" />
 					<when state="α" output="Ξ" />
 					<when state="¨" output="Ẍ" />
-					<when state="√" output="∡" />
 				</action>
 			</key>
 			<key code="8">

--- a/EurKEY.bundle/Contents/Resources/EurKEY.keylayout
+++ b/EurKEY.bundle/Contents/Resources/EurKEY.keylayout
@@ -128,7 +128,7 @@
 					<when state="α" output="β" />
 				</action>
 			</key>
-			<key code="10" action="isoKeyBasic" />
+			<key code="10" output="§" />
 			<key code="11">
 				<action>
 					<when state="none" output="b" />
@@ -431,7 +431,7 @@
 					<when state="√" output="√" />
 				</action>
 			</key>
-			<key code="50" action="isoKeyBasic" />
+			<key code="50" output="`" />
 			<key code="51" output="&#x0008;" />
 			<key code="53" output="&#x001B;" />
 			<key code="64" output="&#x0010;" />
@@ -577,7 +577,7 @@
 					<when state="α" output="Β" />
 				</action>
 			</key>
-			<key code="10" action="isoKeyShift" />
+			<key code="10" output="±" />
 			<key code="11">
 				<action>
 					<when state="none" output="B" />
@@ -850,7 +850,12 @@
 					<when state="√" output="≥" />
 				</action>
 			</key>
-			<key code="50" action="isoKeyShift" />
+			<key code="50">
+				<action>
+					<when state="none" output="~" />
+					<when state="√" output="≈" />
+				</action>
+			</key>
 		</keyMap>
 		<keyMap index="2" baseMapSet="ANSI" baseIndex="0">
 			<key code="0" output="ä" />
@@ -863,7 +868,6 @@
 			<key code="7" output="á" />
 			<key code="8" output="ç" />
 			<key code="9" output="ì" />
-			<key code="10" action="isoKeyOption" />
 			<key code="11" output="í" />
 			<key code="12" output="æ" />
 			<key code="13" output="å" />
@@ -930,7 +934,11 @@
 				</action>
 			</key>
 			<key code="47" output="ó" />
-			<key code="50" action="isoKeyOption" />
+			<key code="50">
+				<action>
+					<when state="none" next="`" />
+				</action>
+			</key>
 		</keyMap>
 		<keyMap index="3" baseMapSet="ANSI" baseIndex="0">
 			<key code="0" output="Ä" />
@@ -943,7 +951,6 @@
 			<key code="7" output="Á" />
 			<key code="8" output="Ç" />
 			<key code="9" output="Ì" />
-			<key code="10" action="isoKeyOptionShift" />
 			<key code="11" output="Í" />
 			<key code="12" output="Æ" />
 			<key code="13" output="Å" />
@@ -996,7 +1003,11 @@
 				</action>
 			</key>
 			<key code="47" output="Ó" />
-			<key code="50" action="isoKeyOptionShift" />
+			<key code="50">
+				<action>
+					<when state="none" next="~" />
+				</action>
+			</key>
 		</keyMap>
 		<keyMap index="4" baseMapSet="ANSI" baseIndex="0">
 			<key code="0">
@@ -1323,19 +1334,6 @@
 		</keyMap>
 	</keyMapSet>
 	<actions>
-		<action id="isoKeyBasic">
-			<when state="none" output="`" />
-		</action>
-		<action id="isoKeyShift">
-			<when state="none" output="~" />
-			<when state="√" output="≈" />
-		</action>
-		<action id="isoKeyOption">
-			<when state="none" next="`" />
-		</action>
-		<action id="isoKeyOptionShift">
-			<when state="none" next="~" />
-		</action>
 	</actions>
 	<terminators>
 		<when state="`" output="`" />

--- a/EurKEY.bundle/Contents/Resources/EurKEY.keylayout
+++ b/EurKEY.bundle/Contents/Resources/EurKEY.keylayout
@@ -469,6 +469,7 @@
 			<key code="109" output="&#x0010;" />
 			<key code="111" output="&#x0010;" />
 			<key code="113" output="&#x0010;" />
+			<key code="114" output="&#x0005;"/>
 			<key code="115" output="&#x0001;" />
 			<key code="116" output="&#x000B;" />
 			<key code="117" output="&#x007F;" />


### PR DESCRIPTION
Hi!
Thank's for this great repo. I discovered that the keylayout file contained some minor errors in the α and √ dead key layers. More specifically, the `∡`, `₊` and `″` symbols were either misplaced or missing. 
Additionally, on an US keyboard that uses the ISO layout, the \`~ key moves between the left shift and z key. In its place there should be a §± key. That way the EurKEY layout remains consistent with what is printed on the keys. This was not the case (instead both keys were exactly the same and produced \`~) so I decided to fix this as well.