### PR TITLE
Fix "ë" symbol on "e" key

### DIFF
--- a/EurKEY.bundle/Contents/Resources/EurKEY.keylayout
+++ b/EurKEY.bundle/Contents/Resources/EurKEY.keylayout
@@ -874,7 +874,7 @@
 			<key code="11" output="í" />
 			<key code="12" output="æ" />
 			<key code="13" output="å" />
-			<key code="14" output="è" />
+			<key code="14" output="ë" />
 			<key code="15" output="ý" />
 			<key code="16" output="ÿ" />
 			<key code="17" output="þ" />


### PR DESCRIPTION
Hi again,

It seems to me that the symbol `ë` is not being correctly mapped.

According to the EurKEY layout it should appear under the `e` when pressing the modifier key `option ⌥` (Alt Gr in Windows). Currently, in this position appears the `è` symbol, which can also be found under the `f` key:

![Wrong_symbol](https://user-images.githubusercontent.com/38757307/174501844-42e038f5-a2af-4606-8c99-e6b618b00f68.png)

I fixed it just by changing the mapping on that key:

![Fixed_symbol](https://user-images.githubusercontent.com/38757307/174501848-4c0586ea-0a0b-4ef4-8930-addce9f561dc.png)

Thanks once again for porting this layout to macOS users!